### PR TITLE
Fixes #156

### DIFF
--- a/old/html/faq_v6ns_bad.html
+++ b/old/html/faq_v6ns_bad.html
@@ -15,7 +15,7 @@ Public DNS, you'll test those services instead. " | i18n %]</p>
 
 <p><b>[% " If this test fails: " | i18n %]</b>  
 [% " it means that the DNS resolver you are using,
-requires IPv4 to reach the DNS authoritative servers of your favoriate web
+requires IPv4 to reach the DNS authoritative servers of your favorite web
 sites.  In the near future, every web site of consequence will remain
 accessible in this form, so <b>there is no immediate danger.</b> " | i18n %]</p>
 

--- a/old/po-snapshot/dl/af/falling-sky.af_ZA.po
+++ b/old/po-snapshot/dl/af/falling-sky.af_ZA.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/bg/falling-sky.bg_BG.po
+++ b/old/po-snapshot/dl/bg/falling-sky.bg_BG.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/cs/falling-sky.cs_CZ.po
+++ b/old/po-snapshot/dl/cs/falling-sky.cs_CZ.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/de/falling-sky.de_DE.po
+++ b/old/po-snapshot/dl/de/falling-sky.de_DE.po
@@ -1952,7 +1952,7 @@ msgid "If this test fails:"
 msgstr "Wenn dieser Test fehlschlägt:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "Es bedeutet, dass der DNS-Resolver, den Sie verwenden, IPv4 erfordert um die autorisierenden DNS-Server für Ihre Websites zu erreichen. In naher Zukunft wird jede Website von Bedeutung in dieser Form zugänglich bleiben, also <b>gibt es keine unmittelbare Gefahr dadurch.</b>"
 
 #: faq_v6ns_bad.html

--- a/old/po-snapshot/dl/el/falling-sky.el_GR.po
+++ b/old/po-snapshot/dl/el/falling-sky.el_GR.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "Αν αυτή η δοκιμή αποτυγχάνει:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/es-ES/falling-sky.es_ES.po
+++ b/old/po-snapshot/dl/es-ES/falling-sky.es_ES.po
@@ -1952,7 +1952,7 @@ msgid "If this test fails:"
 msgstr "Si esta prueba falla:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "significa que la resolución DNS que usa, requiere IPv4 para llegar a los servidores DNS autoritativos de sus sitios web favoritos. En un futuro próximo, cada sitio web importante permanecerá accesible en esta forma, así que <b>no hay ningún peligro inmediato.</b>"
 
 #: faq_v6ns_bad.html

--- a/old/po-snapshot/dl/fa/falling-sky.fa_IR.po
+++ b/old/po-snapshot/dl/fa/falling-sky.fa_IR.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/fi/falling-sky.fi_FI.po
+++ b/old/po-snapshot/dl/fi/falling-sky.fi_FI.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/fr/falling-sky.fr_FR.po
+++ b/old/po-snapshot/dl/fr/falling-sky.fr_FR.po
@@ -1951,7 +1951,7 @@ msgid "If this test fails:"
 msgstr "Si ce test échoue:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "cela signifie que votre resolver DNS a besoin d'IPv4 pour contacter les serveurs DNS autoritaires. Dans un future proche, tous les sites web resteront de toutes fa&ccedil;ons disponibles par ce moyen, donc, <b>il n'y a pas de problèmes immédiats.</b>"
 
 #: faq_v6ns_bad.html

--- a/old/po-snapshot/dl/hr/falling-sky.hr_HR.po
+++ b/old/po-snapshot/dl/hr/falling-sky.hr_HR.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/hu/falling-sky.hu_HU.po
+++ b/old/po-snapshot/dl/hu/falling-sky.hu_HU.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/it/falling-sky.it_IT.po
+++ b/old/po-snapshot/dl/it/falling-sky.it_IT.po
@@ -1952,8 +1952,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/ja/falling-sky.ja_JP.po
+++ b/old/po-snapshot/dl/ja/falling-sky.ja_JP.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/nb/falling-sky.nb_NO.po
+++ b/old/po-snapshot/dl/nb/falling-sky.nb_NO.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/nl/falling-sky.nl_NL.po
+++ b/old/po-snapshot/dl/nl/falling-sky.nl_NL.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/pl/falling-sky.pl_PL.po
+++ b/old/po-snapshot/dl/pl/falling-sky.pl_PL.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/pt-BR/falling-sky.pt_BR.po
+++ b/old/po-snapshot/dl/pt-BR/falling-sky.pt_BR.po
@@ -1951,7 +1951,7 @@ msgid "If this test fails:"
 msgstr "Se este teste falhar:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "isto significa que o resolvedor DNS que você está utilizando requer IPv4 para alcançar os servidores autoritativos dos seus sites favoritos. Num futuro próximo, cada site vai permanecer acessível desta forma, então <b>não há nenhum perigo imediato</b>."
 
 #: faq_v6ns_bad.html

--- a/old/po-snapshot/dl/ro/falling-sky.ro_RO.po
+++ b/old/po-snapshot/dl/ro/falling-sky.ro_RO.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/ru/falling-sky.ru_RU.po
+++ b/old/po-snapshot/dl/ru/falling-sky.ru_RU.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "Если этот тест завершается ошибкой:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/sk/falling-sky.sk_SK.po
+++ b/old/po-snapshot/dl/sk/falling-sky.sk_SK.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/sq/falling-sky.sq_AL.po
+++ b/old/po-snapshot/dl/sq/falling-sky.sq_AL.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "Nëse ky test dështon:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/sv-SE/falling-sky.sv_SE.po
+++ b/old/po-snapshot/dl/sv-SE/falling-sky.sv_SE.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/tr/falling-sky.tr_TR.po
+++ b/old/po-snapshot/dl/tr/falling-sky.tr_TR.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/zh-CN/falling-sky.zh_CN.po
+++ b/old/po-snapshot/dl/zh-CN/falling-sky.zh_CN.po
@@ -1951,7 +1951,7 @@ msgid "If this test fails:"
 msgstr "如果此测试失败："
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "这意味着您使用的 DNS 服务器需要 IPv4 来到达您喜欢的网站的 DNS 权威服务器。在目前来说，基本每个网站都仍可以用此种形式访问，因此此情况<b>目前没有风险</b>。"
 
 #: faq_v6ns_bad.html

--- a/old/po-snapshot/dl/zh-HK/falling-sky.zh_HK.po
+++ b/old/po-snapshot/dl/zh-HK/falling-sky.zh_HK.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/dl/zh-TW/falling-sky.zh_TW.po
+++ b/old/po-snapshot/dl/zh-TW/falling-sky.zh_TW.po
@@ -1951,8 +1951,8 @@ msgid "If this test fails:"
 msgstr "If this test fails:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
-msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgstr "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 
 #: faq_v6ns_bad.html
 msgid "If this test succeeds:"

--- a/old/po-snapshot/falling-sky.pot
+++ b/old/po-snapshot/falling-sky.pot
@@ -1938,7 +1938,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/af/falling-sky.af_ZA.po
+++ b/old/po/dl/af/falling-sky.af_ZA.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/az/falling-sky.az_AZ.po
+++ b/old/po/dl/az/falling-sky.az_AZ.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Əgər bu test uğursuz olarsa:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/cs/falling-sky.cs_CZ.po
+++ b/old/po/dl/cs/falling-sky.cs_CZ.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/de/falling-sky.de_DE.po
+++ b/old/po/dl/de/falling-sky.de_DE.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Wenn dieser Test fehlschlägt:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "Es bedeutet, dass der DNS-Resolver, den Sie verwenden, IPv4 erfordert um die autorisierenden DNS-Server für Ihre Websites zu erreichen. In naher Zukunft wird jede Website von Bedeutung in dieser Form zugänglich bleiben, also <b>gibt es keine unmittelbare Gefahr dadurch.</b>"
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/el/falling-sky.el_GR.po
+++ b/old/po/dl/el/falling-sky.el_GR.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Αν αυτή η δοκιμή αποτυγχάνει:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/es-ES/falling-sky.es_ES.po
+++ b/old/po/dl/es-ES/falling-sky.es_ES.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Si esta prueba falla:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "significa que la resolución DNS que usa, requiere IPv4 para llegar a los servidores DNS autoritativos de sus sitios web favoritos. En un futuro próximo, cada sitio web importante permanecerá accesible en esta forma, así que <b>no hay ningún peligro inmediato.</b>"
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/fi/falling-sky.fi_FI.po
+++ b/old/po/dl/fi/falling-sky.fi_FI.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/fr/falling-sky.fr_FR.po
+++ b/old/po/dl/fr/falling-sky.fr_FR.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Si ce test échoue:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "cela signifie que votre resolver DNS a besoin d'IPv4 pour contacter les serveurs DNS autoritaires. Dans un future proche, tous les sites web resteront de toutes fa&ccedil;ons disponibles par ce moyen, donc, <b>il n'y a pas de problèmes immédiats.</b>"
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/hr/falling-sky.hr_HR.po
+++ b/old/po/dl/hr/falling-sky.hr_HR.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/hu/falling-sky.hu_HU.po
+++ b/old/po/dl/hu/falling-sky.hu_HU.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/it/falling-sky.it_IT.po
+++ b/old/po/dl/it/falling-sky.it_IT.po
@@ -1970,7 +1970,7 @@ msgid "If this test fails:"
 msgstr "Se questo test fallisce"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "significa che il server DNS utilizzato usa solo IPv4 per raggiungere il server DNS autorevole per il sito web richiesto. Nel prossimo futuro ogni sito rimarrà accessibile in questo modo, per cui <b>non c'è nessun pericolo immediato</b>."
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/ja/falling-sky.ja_JP.po
+++ b/old/po/dl/ja/falling-sky.ja_JP.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/nb/falling-sky.nb_NO.po
+++ b/old/po/dl/nb/falling-sky.nb_NO.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/nl/falling-sky.nl_NL.po
+++ b/old/po/dl/nl/falling-sky.nl_NL.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/pl/falling-sky.pl_PL.po
+++ b/old/po/dl/pl/falling-sky.pl_PL.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/pt-BR/falling-sky.pt_BR.po
+++ b/old/po/dl/pt-BR/falling-sky.pt_BR.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Se este teste falhar:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "isto significa que o resolvedor DNS que você está utilizando requer IPv4 para alcançar os servidores autoritativos dos seus sites favoritos. Num futuro próximo, cada site vai permanecer acessível desta forma, então <b>não há nenhum perigo imediato</b>."
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/ro/falling-sky.ro_RO.po
+++ b/old/po/dl/ro/falling-sky.ro_RO.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/ru/falling-sky.ru_RU.po
+++ b/old/po/dl/ru/falling-sky.ru_RU.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Если этот тест завершается ошибкой:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/sk/falling-sky.sk_SK.po
+++ b/old/po/dl/sk/falling-sky.sk_SK.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/sq/falling-sky.sq_AL.po
+++ b/old/po/dl/sq/falling-sky.sq_AL.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Nëse ky test dështon:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/sv-SE/falling-sky.sv_SE.po
+++ b/old/po/dl/sv-SE/falling-sky.sv_SE.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "Om det här testet misslyckas:"
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "Det innebär att DNS-resolvern du använder kräver IPv4 för att nå de auktoritära DNS-servrarna för dina favoritwebbplatser. I närtid kommer alla viktiga webbplatser förbli tillgängliga i denna form, så <b>det finns ingen omedelbar fara</b>."
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/tr/falling-sky.tr_TR.po
+++ b/old/po/dl/tr/falling-sky.tr_TR.po
@@ -1970,7 +1970,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/zh-CN/falling-sky.zh_CN.po
+++ b/old/po/dl/zh-CN/falling-sky.zh_CN.po
@@ -1969,7 +1969,7 @@ msgid "If this test fails:"
 msgstr "如果此测试失败："
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "这意味着您使用的 DNS 服务器需要 IPv4 来到达您喜欢的网站的 DNS 权威服务器。在目前来说，基本每个网站都仍可以用此种形式访问，因此此情况<b>目前没有风险</b>。"
 
 #: faq_v6ns_bad.html

--- a/old/po/dl/zh-TW/falling-sky.zh_TW.po
+++ b/old/po/dl/zh-TW/falling-sky.zh_TW.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/old/po/falling-sky.pot
+++ b/old/po/falling-sky.pot
@@ -1958,7 +1958,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: faq_v6ns_bad.html
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: faq_v6ns_bad.html

--- a/templates/html/faq_v6ns_bad.html
+++ b/templates/html/faq_v6ns_bad.html
@@ -16,7 +16,7 @@ Public DNS, you'll test those services instead. }}</p>
 
 <p><b>{{ If this test fails: }}</b>  
 {{ it means that the DNS resolver you are using,
-requires IPv4 to reach the DNS authoritative servers of your favoriate web
+requires IPv4 to reach the DNS authoritative servers of your favorite web
 sites.  In the near future, every web site of consequence will remain
 accessible in this form, so <b>there is no immediate danger.</b> }}</p>
 

--- a/translations/dl/af/falling-sky.af_ZA.po
+++ b/translations/dl/af/falling-sky.af_ZA.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/az/falling-sky.az_AZ.po
+++ b/translations/dl/az/falling-sky.az_AZ.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Əgər bu test uğursuz olarsa:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/cs/falling-sky.cs_CZ.po
+++ b/translations/dl/cs/falling-sky.cs_CZ.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/de/falling-sky.de_DE.po
+++ b/translations/dl/de/falling-sky.de_DE.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Wenn dieser Test fehlschlägt:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "Es bedeutet, dass der DNS-Resolver, den Sie verwenden, IPv4 erfordert um die autorisierenden DNS-Server für Ihre Websites zu erreichen. In naher Zukunft wird jede Website von Bedeutung in dieser Form zugänglich bleiben, also <b>gibt es keine unmittelbare Gefahr dadurch.</b>"
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/el/falling-sky.el_GR.po
+++ b/translations/dl/el/falling-sky.el_GR.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Αν αυτή η δοκιμή αποτυγχάνει:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/es-ES/falling-sky.es_ES.po
+++ b/translations/dl/es-ES/falling-sky.es_ES.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Si esta prueba falla:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "significa que la resolución DNS que usa, requiere IPv4 para llegar a los servidores DNS autoritativos de sus sitios web favoritos. En un futuro próximo, cada sitio web importante permanecerá accesible en esta forma, así que <b>no hay ningún peligro inmediato.</b>"
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/fi/falling-sky.fi_FI.po
+++ b/translations/dl/fi/falling-sky.fi_FI.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/fr/falling-sky.fr_FR.po
+++ b/translations/dl/fr/falling-sky.fr_FR.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Si ce test échoue:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "cela signifie que votre resolver DNS a besoin d'IPv4 pour contacter les serveurs DNS autoritaires. Dans un future proche, tous les sites web resteront de toutes fa&ccedil;ons disponibles par ce moyen, donc, <b>il n'y a pas de problèmes immédiats.</b>"
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/hr/falling-sky.hr_HR.po
+++ b/translations/dl/hr/falling-sky.hr_HR.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/hu/falling-sky.hu_HU.po
+++ b/translations/dl/hu/falling-sky.hu_HU.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/it/falling-sky.it_IT.po
+++ b/translations/dl/it/falling-sky.it_IT.po
@@ -1972,7 +1972,7 @@ msgid "If this test fails:"
 msgstr "Se questo test fallisce"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "significa che il server DNS utilizzato usa solo IPv4 per raggiungere il server DNS autorevole per il sito web richiesto. Nel prossimo futuro ogni sito rimarrà accessibile in questo modo, per cui <b>non c'è nessun pericolo immediato</b>."
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/ja/falling-sky.ja_JP.po
+++ b/translations/dl/ja/falling-sky.ja_JP.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/ko/falling-sky.ko_KR.po
+++ b/translations/dl/ko/falling-sky.ko_KR.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "이 테스트가 실패하는 경우:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "이것은 즐겨 찾는 웹 사이트의 신뢰할 만한 DNS 서버에 연결하기 위해서는 사용 중인 DNS 변환기에 IPv4가 필요한 것을 의미합니다. 머지않아 중요한 모든 웹 사이트는 이런 형태로 액세스가 가능할 것이므로, <b>즉각적인 위험은 없습니다.</b>"
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/nb/falling-sky.nb_NO.po
+++ b/translations/dl/nb/falling-sky.nb_NO.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/nl/falling-sky.nl_NL.po
+++ b/translations/dl/nl/falling-sky.nl_NL.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/pl/falling-sky.pl_PL.po
+++ b/translations/dl/pl/falling-sky.pl_PL.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/pt-BR/falling-sky.pt_BR.po
+++ b/translations/dl/pt-BR/falling-sky.pt_BR.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Se este teste falhar:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "isto significa que o resolvedor DNS que você está utilizando requer IPv4 para alcançar os servidores autoritativos dos seus sites favoritos. Num futuro próximo, cada site vai permanecer acessível desta forma, então <b>não há nenhum perigo imediato</b>."
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/ro/falling-sky.ro_RO.po
+++ b/translations/dl/ro/falling-sky.ro_RO.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/ru/falling-sky.ru_RU.po
+++ b/translations/dl/ru/falling-sky.ru_RU.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Если этот тест завершается ошибкой:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/sk/falling-sky.sk_SK.po
+++ b/translations/dl/sk/falling-sky.sk_SK.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/sq/falling-sky.sq_AL.po
+++ b/translations/dl/sq/falling-sky.sq_AL.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Nëse ky test dështon:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/sv-SE/falling-sky.sv_SE.po
+++ b/translations/dl/sv-SE/falling-sky.sv_SE.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "Om det här testet misslyckas:"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "Det innebär att DNS-resolvern du använder kräver IPv4 för att nå de auktoritära DNS-servrarna för dina favoritwebbplatser. I närtid kommer alla viktiga webbplatser förbli tillgängliga i denna form, så <b>det finns ingen omedelbar fara</b>."
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/tr/falling-sky.tr_TR.po
+++ b/translations/dl/tr/falling-sky.tr_TR.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/zh-CN/falling-sky.zh_CN.po
+++ b/translations/dl/zh-CN/falling-sky.zh_CN.po
@@ -1971,7 +1971,7 @@ msgid "If this test fails:"
 msgstr "如果此测试失败："
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "这意味着您使用的 DNS 服务器需要 IPv4 来到达您喜欢的网站的 DNS 权威服务器。在目前来说，基本每个网站都仍可以用此种形式访问，因此此情况<b>目前没有风险</b>。"
 
 #: "faq_v6ns_bad.html"

--- a/translations/dl/zh-TW/falling-sky.zh_TW.po
+++ b/translations/dl/zh-TW/falling-sky.zh_TW.po
@@ -1973,7 +1973,7 @@ msgid "If this test fails:"
 msgstr "如果這個測試失敗 ︰"
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr "這意味著，DNS 解析器使用的需要使用 IPv4 到達你最喜歡的 web 網站的 DNS 權威伺服器。在不久的將來，每個 web 網站的後果將仍然可以訪問在此表單，所以 <b>沒有立即的危險。</b>"
 
 #: "faq_v6ns_bad.html"

--- a/translations/falling-sky.newpot
+++ b/translations/falling-sky.newpot
@@ -1975,7 +1975,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"

--- a/translations/falling-sky.pot
+++ b/translations/falling-sky.pot
@@ -1965,7 +1965,7 @@ msgid "If this test fails:"
 msgstr ""
 
 #: "faq_v6ns_bad.html"
-msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favoriate web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
+msgid "it means that the DNS resolver you are using, requires IPv4 to reach the DNS authoritative servers of your favorite web sites. In the near future, every web site of consequence will remain accessible in this form, so <b>there is no immediate danger.</b>"
 msgstr ""
 
 #: "faq_v6ns_bad.html"


### PR DESCRIPTION
favoriate -> favorite
I checked a few of the translations and it appears that translators
were able to correct ‘favoriate’ to ‘favorite’ before translating.