### PR TITLE
Fixed that function help_page () does not work.

### DIFF
--- a/templates/html/inc/header.inc
+++ b/templates/html/inc/header.inc
@@ -34,8 +34,11 @@ BrowserName="IE6";
 //  make same function load entire document with real headers
 function help_page (url,text) {
   try {
+// Since this function does not work in all languages, open the URL directly as an ad hoc fix.
+// Sorry, I have not found out how to fix this.
 //      GIGO.help_popup(url + " #content",text);
-      GIGO.help_popup(url,text);
+//      GIGO.help_popup(url,text);
+	window.location.href = url;
   }
   catch (err) {
     document.location = url;


### PR DESCRIPTION
The correct logic of  function help_page () is preparing a new tab in the browser and opening the specified HTML document there, but this function is not working on Safari, Chorome, Firefox, IE11.
As a ad hoc fix, we opened a page directly specified using "window.location.href" in this function.