### PR TITLE
https support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ output: FORCE
 
 pipeline: pre output post
 
+
 crowdin-upload:
 	@echo Uploading crowdin strings to translate | ./support/fold_start.sh $@
 ifeq ($(TRAVIS_PUBLISH),true)
@@ -138,7 +139,7 @@ dist-stable:
 # Real targets.                                                #
 ################################################################
 
-beta: pipeline
+beta: fsbuilder output
 	@echo Publishing to beta server | ./support/fold_start.sh $@
 	rsync output/. $(BETA)/.  -a --exclude site --delete -z
 	@./support/fold_end.sh $@

--- a/templates/html/faq_https.html
+++ b/templates/html/faq_https.html
@@ -1,0 +1,51 @@
+[% PROCESS "inc/header.inc" %]
+[% $page := "Using HTTPS" %]
+[% PROCESS "inc/list-nav.inc" %]
+
+<div id="content">
+
+<h1>{{Differences in HTTP vs HTTPS}}</h1>
+<p>{{HTTP and HTTPS bring us different testing capabilities.  Unfortunately, we can not test both at once.  You can choose which features to test for, by using http://test-ipv6.com or https://test-ipv6.com.}}</p>
+<p>{{<b>HTTP</b> allows us to test for Teredo and 6to4.  Both are transitional technologies.
+  Modern operating systems by default no longer use those, unless there is no other choice.
+  Windows, for example, will not use Teredo, when the browser is given a DNS name to connect to.
+  However, Windows will attempt to use Teredo, when told an IPv6-only IP address.  6to4
+  is similarly deprecated; and only likely used if there is no other choice.}}</p>
+
+<p>{{HTTP also allows us to detect certain types of DNS64/NAT64.
+  NAT64 is a migration strategy that allows for an eventual IPv6-only Internet.
+  Until then, connections to the IPv4 Internet are translated.
+  We detect this by making connections to literal IP address, such as http://192.0.2.1/
+  (with a server-specific IP address).
+  We are able to detect NAT64 in particular when there is no local IPv4 tunnel
+  (464xlat on Android) or OS assistance (Apple iOS, Apple MacOS).
+}}
+
+<p>{{<b>HTTPS</b>, which ensures a trusted transport from you to the server,
+  allows bypassing many corporate and mobile proxy servers.
+  There are exceptions; particularly if you agreed to install their certificate;
+  but that is generally not advised.  Bypassing these proxies allows us to show
+  you a better idea of your IP address - something that represents your location,
+  and your connectivity to the IPv6 Internet.</p>
+
+  <p>{{A limitation of using HTTPS exists.  Since HTTPS requires certificates,
+    and certificates are not offered to IP addresses (but instead to web site names),
+    we can't test for NAT64, 6to4, or Teredo.}}</p>
+
+
+<h1>{{Should I use HTTP or HTTPS?}}</h1>
+
+<p>{{If you're in a new location, or a computer you're not familiar with,
+  consider both!.  If both come up with the same results, you can
+  pick http for speed, or https to bypass certain proxies.}}</p>
+
+<p>{{Links:}}</p>
+<ul>
+    <li><a href="javascript:window.location=window.location.href.replace('http://', 'https://');">https</a>
+    <li><a href="javascript:window.location=window.location.href.replace('https://', 'http://');">http</a>
+</ul>
+
+
+
+
+[% PROCESS "inc/footer.inc" %]

--- a/templates/js/inc/builtin.js
+++ b/templates/js/inc/builtin.js
@@ -17,6 +17,9 @@ GIGO.generate_share_link_entry = function (name, def) {
         if ((t.status === "bad") || (t.status === "timeout")) {
             s = "&" + name + "=" + encodeURIComponent(t.status) + "," + encodeURIComponent(t.time_ms);
         }
+        if ((t.status === "skipped")) {
+            s = "&" + name + "=" + encodeURIComponent(t.status) + "," + encodeURIComponent(t.time_ms);
+        }
     } catch (e) {
         noop = 1;
     }
@@ -228,11 +231,14 @@ GIGO.update_status = function (id) {
     // id = the update we just received (ie, "test_a", "test_aaaa")
     // ipinfo.ip  = text form of ip;  ipinfo.type = "ipv4" or "ipv6";  ipinfo.subtype MAY say "Teredo" or "6to4"
     var status, status_translated, time_ms, ipinfo, content, url, proxied;
-    status = GIGO.results.tests[id].status; // This should be ok/bad/slow/timeout
+    status = GIGO.results.tests[id].status; // This should be ok/bad/slow/timeout/skipped
     status_translated = GIGO.messages[status];
     time_ms = GIGO.results.tests[id].time_ms; // This should be number of milliseconds spent
     ipinfo = GIGO.results.tests[id].ipinfo; // This may be "undef"
     url = GIGO.results.tests[id].url;
+
+    // Should we detect "skipped", and hide the content?
+
 
     if (!time_ms) {
         content = "{{Started}}";
@@ -320,7 +326,7 @@ GIGO.send_survey_global = function (tokens) {
         GIGO.send_survey(tokens);
      }
   }
-}
+};
 
 
 GIGO.send_survey = function (tokens) {
@@ -333,9 +339,9 @@ GIGO.send_survey = function (tokens) {
     if (MirrorConfig.options.userdata) {
         // We're going to completely override "url"
         if (GIGO.results.ipv4.ip) {
-            url = "http://ipv4." + MirrorConfig.options.userdata + MirrorConfig.options.survey;
+            url = GIGO.protocol  + "ipv4." + MirrorConfig.options.userdata + MirrorConfig.options.survey;
         } else {
-            url = "http://ipv6." + MirrorConfig.options.userdata + MirrorConfig.options.survey;
+            url = GIGO.protocol  + "ipv6." + MirrorConfig.options.userdata + MirrorConfig.options.survey;
         }
     }
 
@@ -448,6 +454,10 @@ GIGO.show_results = function () {
         jQuery("#help_plugins").show(); // Less encouraging of soliciting comments on this one.
     }
 
+
+    // Create href substitutions
+
+
     GIGO.check_versions(); // Check OS, Browser, etc
     // Show the results to the user
     for (i = 0; i < GIGO.results.tokens_expanded.length; i = i + 1) {
@@ -462,6 +472,9 @@ GIGO.show_results = function () {
             // token_expanded.token
             // token_expanded.color
             // token_expanded.text
+
+
+
 
             table = GIGO.results_table_wrapper(token_expanded.color, token_expanded.text);
             jQuery("#results_eof").before(table);
@@ -566,7 +579,7 @@ GIGO.help_popup = function (file, tabname, popup) {
         // hostname (instead of the 'current server');  This is to
         // avoid cross-domain problems.
         hostname = String(document.location.hostname);
-        file = "http://" + hostname + "/" + file;
+        file = GIGO.protocol + hostname + "/" + file;
         lfile = file + '.{{locale}}';
 
 

--- a/templates/js/inc/fake.js
+++ b/templates/js/inc/fake.js
@@ -22,7 +22,7 @@ GIGO.prepare_fake = function () {
 
 GIGO.override_id = function (id, url) {
     var tests, this_test, parts, status, protocol, whichasn;
-    tests = GIGO.results.tests; // Convenience    
+    tests = GIGO.results.tests; // Convenience
     if (!(tests.hasOwnProperty(id))) {
         tests[id] = {};
     }
@@ -51,6 +51,10 @@ GIGO.override_id = function (id, url) {
         } else {
             protocol = "ipv4";
         }
+    }
+    // Is it abbreviated?
+    if (protocol==="6" || protocol==="4") {
+      protocol="ipv"+protocol;
     }
 
     whichasn = "test_asn" + protocol.replace(/^ipv/, "");
@@ -83,7 +87,11 @@ GIGO.override_id = function (id, url) {
         this_test.status = status;
         this_test.time_ms = parseInt(parts[1]) || (GIGO.max_time + 1);
     }
-
+    if (status === "skipped") {
+        this_test.ipinfo = {};
+        this_test.status = status;
+        this_test.time_ms = parseInt(parts[1]) || (0);
+    }
 
     if (id === "test_ds") {
         // We need to populate test_ds4 and test_ds6  in much the same way that GIGO.test_type_json() does
@@ -111,12 +119,13 @@ GIGO.override_id = function (id, url) {
             };
         }
     }
+    this_test.ipinfo.type=protocol;
 
 };
 
 GIGO.override_id_ip = function (id) {
     var tests, this_test, parts, status, protocol, whichasn;
-    tests = GIGO.results.tests; // Convenience    
+    tests = GIGO.results.tests; // Convenience
     this_test = tests[id];
     if (!this_test) {
         return;

--- a/templates/js/inc/helpdesk.js
+++ b/templates/js/inc/helpdesk.js
@@ -41,6 +41,7 @@ GIGO.helpdesk_ob_status = function (n) {
     if (s === "slow") return "g";
     if (s === "bad") return "b";
     if (s === "timeout") return "t";
+    if (s === "skipped") return "x";
 };
 GIGO.helpdesk_ob_type = function () {
     //# global,bad,teredo,6to4,asn(different)
@@ -72,6 +73,8 @@ GIGO.helpdesk_score = function () {
 
     var status = status_a + status_ipv4 + ":" + status_aaaa + status_ipv6_type;
     var ob = new Object;
+
+    console.log("helpdesk status code %o",status);
 
     ob.found = GIGO.sym_helpdesk[status];
     ob.qcode = GIGO.sym_helpdesk_qcode[ob.found];
@@ -248,8 +251,8 @@ GIGO.finish_helpdesk = function () {
     // GIGO.results.mini_primary
     // GIGO.results.mini_secondary
 
-    // This is meant to be ran several times; each time will replace 
-    // #helpdesk_content 
+    // This is meant to be ran several times; each time will replace
+    // #helpdesk_content
 
     // First time replaced, will be before the "other sites" tab starts.
     // If we have IPV6, then it should say "checking other sites.."

--- a/templates/js/inc/init.js
+++ b/templates/js/inc/init.js
@@ -22,7 +22,7 @@ GIGO.results = {}; // what we want to expose as "this" to callback functions
 GIGO.results.ipv4 = {
     ip: "",
     subtype: ""
-}; // Customer IP information, per our web service call 
+}; // Customer IP information, per our web service call
 GIGO.results.ipv6 = {
     ip: "",
     subtype: ""
@@ -33,7 +33,7 @@ GIGO.results.tests = {}; // Store test specific data here.
 GIGO.tabhistory = ["main"]; // History of what tab we go to and when; used for GIGO.goback()
 
 GIGO.tests_planned = 0; // As we add tests, this will be incremented.  Used by progress bar.
-GIGO.tests_finished = 0; // As we finish tests, this will be incremented. Used by progress bar. 
+GIGO.tests_finished = 0; // As we finish tests, this will be incremented. Used by progress bar.
 GIGO.start_time = GIGO.getms(); // Starting time.  Used by progress bar as well as by retry_until
 GIGO.finished = 0; // When we're done with all tests, set to 1 to hide the progress bar
 GIGO.slowcount = 0; // How many background jsonp we spawned so far. Used when we execute tasks in parallel to stagger load.
@@ -79,6 +79,10 @@ if (navigator.userAgent.match(/SymbianOS|SymbOS/)) {
     GIGO.slow = 9000;
 }
 
+// What protocol (http, https) should we make our URLs?
+// Force it into https:// or http:// (even though our inputs might say http or http:)
+GIGO.protocol =   MirrorConfig.options.protocol ? MirrorConfig.options.protocol   : document.location.protocol;
+GIGO.protocol = (GIGO.protocol.match(/https/))  ? "https://" : "http://";
 
 
 GIGO.parseGetVars = function () {

--- a/templates/js/inc/main.js
+++ b/templates/js/inc/main.js
@@ -79,6 +79,8 @@ GIGO.test_type_json = function (url, id) {
     // Update status to "Started" if we don't have any time for this yet
 
 
+
+
     if (GIGO.overrides && GIGO.overrides[id]) {
         // oh, we're faking this one.  TODO
         // we can take a lot of short cuts.
@@ -168,6 +170,12 @@ GIGO.test_type_json = function (url, id) {
             }
             this_test.status = (this_test.time_ms < GIGO.slow) ? "bad" : "timeout";
 
+            if (GIGO.protocol==="https://") {
+              if ((id==="test_ipv4") || (id==="test_ipv6")) {
+                // We expected this to fail.
+                this_test.status = "skipped";
+              }
+            }
 
             // Look for dual stack
             if (id === "test_ds") {
@@ -198,8 +206,8 @@ GIGO.test_type_json = function (url, id) {
     GIGO.update_url(id);
     GIGO.show_debug();
 
-
 };
+
 
 GIGO.test_type_json_only = function (url, id) {
     // name = dns name to fetch
@@ -650,31 +658,31 @@ GIGO.set_default_options = function (options) {
 
 
     // options.uri = "/report-ip.php?callback=?";  // Alternative to mod_ip
-    options.url.test_a = "http://ipv4." + options.subdomain + options.uri;
-    options.url.test_aaaa = "http://ipv6." + options.subdomain + options.uri;
-    options.url.test_ds = "http://ds." + options.subdomain + options.uri;
-    options.url.test_ipv4 = "http://" + options.ipv4 + options.uri;
-    options.url.test_ipv6 = "http://[" + options.ipv6 + "]:80" + options.uri;
-    options.url.test_v6ns = "http://ds.v6ns." + options.subdomain + options.uri;
-    options.url.test_v6mtu = "http://mtu1280." + options.subdomain + options.uri + "&size=1600&fill=" + GIGO.fill(1600, "x");
-    options.url.test_dsmtu = "http://ds." + options.subdomain + options.uri + "&size=1600&fill=" + GIGO.fill(1600, "x");
-    options.url.test_buggydns1 = "http://buggydns1." + options.subdomain + options.uri;
+    options.url.test_a = GIGO.protocol+"ipv4." + options.subdomain + options.uri;
+    options.url.test_aaaa = GIGO.protocol+"ipv6." + options.subdomain + options.uri;
+    options.url.test_ds = GIGO.protocol+"ds." + options.subdomain + options.uri;
+    options.url.test_ipv4 = GIGO.protocol+"" + options.ipv4 + options.uri;
+    options.url.test_ipv6 = GIGO.protocol+"[" + options.ipv6 + "]:80" + options.uri;
+    options.url.test_v6ns = GIGO.protocol+"ds.v6ns." + options.subdomain + options.uri;
+    options.url.test_v6mtu = GIGO.protocol+"mtu1280." + options.subdomain + options.uri + "&size=1600&fill=" + GIGO.fill(1600, "x");
+    options.url.test_dsmtu = GIGO.protocol+"ds." + options.subdomain + options.uri + "&size=1600&fill=" + GIGO.fill(1600, "x");
+    options.url.test_buggydns1 = GIGO.protocol+"buggydns1." + options.subdomain + options.uri;
 
 
     // ASN lookups are corrently broken.
-    options.url.test_asn4 = "http://ipv4.lookup.test-ipv6.com" + options.uri + "&asn=1";
-    options.url.test_asn6 = "http://ipv6.lookup.test-ipv6.com" + options.uri + "&asn=1";
+    options.url.test_asn4 = GIGO.protocol+"ipv4.lookup.test-ipv6.com" + options.uri + "&asn=1";
+    options.url.test_asn6 = GIGO.protocol+"ipv6.lookup.test-ipv6.com" + options.uri + "&asn=1";
 
 
-    options.url.test_a_img = "http://ipv4." + options.subdomain + options.img_uri;
-    options.url.test_aaaa_img = "http://ipv6." + options.subdomain + options.img_uri;
-    options.url.test_ds_img = "http://ds." + options.subdomain + options.img_uri;
-    options.url.test_ipv4_img = "http://" + options.ipv4 + options.img_uri;
-    options.url.test_ipv6_img = "http://[" + options.ipv6 + "]:80" + options.img_uri;
-    options.url.test_v6ns_img = "http://ds.v6ns." + options.subdomain + options.img_uri;
-    options.url.test_v6mtu_img = "http://mtu1280." + options.subdomain + options.img_uri_big;
-    options.url.test_dsmtu_img = "http://ds." + options.subdomain + options.img_uri_big;
-    options.url.test_buggydns1_img = "http://buggydns1." + options.subdomain + options.img_uri;
+    options.url.test_a_img = GIGO.protocol+"ipv4." + options.subdomain + options.img_uri;
+    options.url.test_aaaa_img = GIGO.protocol+"ipv6." + options.subdomain + options.img_uri;
+    options.url.test_ds_img = GIGO.protocol+"ds." + options.subdomain + options.img_uri;
+    options.url.test_ipv4_img = GIGO.protocol+"" + options.ipv4 + options.img_uri;
+    options.url.test_ipv6_img = GIGO.protocol+"[" + options.ipv6 + "]:80" + options.img_uri;
+    options.url.test_v6ns_img = GIGO.protocol+"ds.v6ns." + options.subdomain + options.img_uri;
+    options.url.test_v6mtu_img = GIGO.protocol+"mtu1280." + options.subdomain + options.img_uri_big;
+    options.url.test_dsmtu_img = GIGO.protocol+"ds." + options.subdomain + options.img_uri_big;
+    options.url.test_buggydns1_img = GIGO.protocol+"buggydns1." + options.subdomain + options.img_uri;
 
 
 
@@ -687,11 +695,11 @@ GIGO.fix_comment_form_and_tab = function () {
         var url = MirrorConfig.options.comment;
         if (MirrorConfig.options.userdata) {
             if (GIGO.results.ipv4.ip) {
-                url = "http://ipv4." + MirrorConfig.options.userdata + "/comment.php";
+                url = GIGO.protocol+"ipv4." + MirrorConfig.options.userdata + "/comment.php";
             } else if (GIGO.results.ipv6.ip) {
-                url = "http://ipv6." + MirrorConfig.options.userdata + "/comment.php";
+                url = GIGO.protocol+"ipv6." + MirrorConfig.options.userdata + "/comment.php";
             } else {
-                url = "http://ds." + MirrorConfig.options.userdata + "/comment.php";
+                url = GIGO.protocol+"ds." + MirrorConfig.options.userdata + "/comment.php";
             }
         }
 

--- a/templates/js/inc/messages.js
+++ b/templates/js/inc/messages.js
@@ -7,7 +7,9 @@ GIGO.messages = {
     "ok": "{{ok}}",
     "slow": "{{slow}}",
     "timeout": "{{timeout}}",
+    "skipped": "{{skipped}}",
 
+    "tls_warning": "{{We are sometimes unable to detect Teredo and 6to4 when using HTTPS.}}",
     "No Direct IP": "{{Connections to urls with IP addresses appear to be blocked; perhaps by a web filter such as 'NoScript' or 'RequestPolicy' installed into your browser, or filtering in your proxy server.  This limits some of the functionality of this test site.}}",
     "No Direct IPv4": "{{IPv4 Connections using DNS work; but literal IP addresses in urls do not.  These are rarely used on the web today.}}",
     "No Direct IPv6": "{{IPv6 Connections using DNS work; but literal IP addresses in urls do not. These are rarely used on the web today.}}",
@@ -83,5 +85,6 @@ GIGO.messages_popups = {
     "broken": ["broken.html", "{{faq: Broken!}}"],
     "ipv6:nodns": ["faq_broken_aaaa.html", "{{faq: Broken DNS Lookups}}"],
     "avoids_ipv6": ["faq_avoids_ipv6.html", "{{faq: Avoiding IPv6?}}"],
-    "tunnel_6rd_dumb": ["faq_tunnel_6rd.html", "{{faq: 6RD tunnel}}"]
+    "tunnel_6rd_dumb": ["faq_tunnel_6rd.html", "{{faq: 6RD tunnel}}"],
+    "tls_warning" : ["faq_https.html","{{faq: Using HTTPS}}"]
 };

--- a/templates/js/inc/onerror.js
+++ b/templates/js/inc/onerror.js
@@ -11,7 +11,7 @@ window.onerror = function(message, url, linenumber) {
         }
     }
     if (url && linenumber) {
-        eurl = "http://ds.master.test-ipv6.com/errors.php?";
+        eurl = GIGO.protocol + "ds.master.test-ipv6.com/errors.php?";
         eurl = eurl + "message=" + encodeURIComponent(message);
         eurl = eurl + "&url=" + encodeURIComponent(url);
         eurl = eurl + "&linenumber=" + encodeURIComponent(linenumber);
@@ -21,4 +21,3 @@ window.onerror = function(message, url, linenumber) {
     }
     return false;
 };
-

--- a/templates/js/inc/scores.js
+++ b/templates/js/inc/scores.js
@@ -18,6 +18,7 @@ GIGO.scores = {
     "No Direct IP": [10, 10, "ORANGE"],
     "No Direct IPv4": [9, 10, "BLUE"],
     "No Direct IPv6": [10, 10, "BLUE"],
+    "tls_warning": [10, 10, "BLUE"],
     "6to4": [7, 7, "BLUE"],
     "teredo": [7, 7, "BLUE"],
     "teredo-v4pref": [10, 7, "BLUE"],

--- a/templates/js/inc/sym_helpdesk.js
+++ b/templates/js/inc/sym_helpdesk.js
@@ -5,43 +5,66 @@
 // IPV6 by DNS, and IP (values,ok or bad), and IPV6 type (global, 6[6to4], t[teredo],a[asn]
 
 GIGO.sym_helpdesk = {
-//   +------ IPv4 by DNS (good,bad)
-//   |+----- IPv4 by IP (good,bad)
-//   ||:+--- IPv6 by DNS (good,bad)
-//   ||:|+-- IPv6 by IP (global, bad, teredo, 6to4, asn)
-//   ||:||
-    'gg:gg': "Dual Stack",
-    'gg:gt': "IPv4 plus Teredo",
-    'gg:g6': "6to4",
-    'gg:ga': "Dual Stack, Possible Tunnel",
-    'gg:bg': "Dual Stack - but no Quad-A's (AAAA's)",
-    'gg:bb': "IPv4 Only",
-    'gg:bt': "IPv4 Only (Teredo Detected)",
-    'gg:b6': null,
-    'gg:ba': null,
-    'gb:gg': "NAT64",
-    'gt:gg': "NAT64",
-    'gg:tb': "IPv4, plus Broken IPv6",
-    'gb:gt': null,
-    'gb:g6': null,
-    'gb:ga': "NAT64, Possible Tunnel",
-    'gt:ga': "NAT64, Possible Tunnel",
-    'gb:bg': null,
-    'gb:bb': null,
-    'gb:bt': null,
-    'gb:b6': null,
-    'gb:ba': null,
-    'gb:tb': null,
-    'bb:gg': "IPv6 Only",
-    'bb:gt': null,
-    'bb:g6': null,
-    'bb:ga': null,
-    'bb:bg': null,
-    'bb:bb': null,
-    'bb:bt': null,
-    'bb:b6': null,
-    'bb:ba': null,
-    'bb:tb': null
+  //   +------ IPv4 by DNS (good,bad)
+  //   |+----- IPv4 by IP (good,bad)
+  //   ||:+--- IPv6 by DNS (good,bad)
+  //   ||:|+-- IPv6 by IP6 TYPE (global, bad, teredo, 6to4, asn)
+  //   ||:||
+  'gg:gg': "Dual Stack",
+  'gg:gt': "IPv4 plus Teredo",
+  'gg:g6': "6to4",
+  'gg:ga': "Dual Stack, Possible Tunnel",
+  'gg:bg': "Dual Stack - but no Quad-A's (AAAA's)",
+  'gg:bb': "IPv4 Only",
+  'gg:bt': "IPv4 Only (Teredo Detected)",
+  'gg:b6': null,
+  'gg:ba': null,
+  'gb:gg': "NAT64",
+  'gt:gg': "NAT64",
+  'gg:tb': "IPv4, plus Broken IPv6",
+  'gb:gt': null,
+  'gb:g6': null,
+  'gb:ga': "NAT64, Possible Tunnel",
+  'gt:ga': "NAT64, Possible Tunnel",
+  'gb:bg': null,
+  'gb:bb': null,
+  'gb:bt': null,
+  'gb:b6': null,
+  'gb:ba': null,
+  'gb:tb': null,
+  'bb:gg': "IPv6 Only",
+  'bb:gt': null,
+  'bb:g6': null,
+  'bb:ga': null,
+  'bb:bg': null,
+  'bb:bb': null,
+  'bb:bt': null,
+  'bb:b6': null,
+  'bb:ba': null,
+  'bb:tb': null,
+
+  'gx:gg': "Dual Stack",
+  'gx:gt': "IPv4 plus Teredo",
+  'gx:g6': "6to4",
+  'gx:ga': "Dual Stack, Possible Tunnel",
+
+  'gx:bg': null, // Makes no sense using HTTPS
+  'gx:bb': "IPv4 Only",
+  'gx:bt': null, // Makes no sense using HTTPS
+  'gx:b6': null, // Makes no sense using HTTPS
+  'gx:ba': null, // Makes no sense using HTTPS
+
+  'gx:tb': "IPv4, plus Broken IPv6",
+  'bx:gg': "IPv6 Only",
+  'bx:gt': null,
+  'bx:g6': null,
+  'bx:ga': null,
+  'bx:bg': null,
+  'bx:bb': null,
+  'bx:bt': null,
+  'bx:b6': null,
+  'bx:ba': null,
+  'bx:tb': null
 };
 
 GIGO.sym_helpdesk_qcode = {

--- a/templates/js/inc/symptoms.js
+++ b/templates/js/inc/symptoms.js
@@ -36,6 +36,9 @@ GIGO.ministates = function (which) {
         key = which[i];
         try {
             v = GIGO.results.tests["test_" + key].status.charAt(0);
+            if (GIGO.results.tests["test_" + key].status === "skipped") {
+              v="x";
+            }
         } catch (e) {
             v = "?";
         }
@@ -272,6 +275,8 @@ GIGO.identify_symptoms = function () {
     mini_primary = GIGO.ministates(["a", "aaaa", "ds4", "ds6"]);
     mini_secondary = GIGO.ministates(["ipv4", "ipv6", "v6mtu", "v6ns"]);
 
+    console.log("mini_secondary %o",mini_secondary);
+
     GIGO.helpdesk.mini_primary = mini_primary;
     GIGO.helpdesk.mini_secondary = mini_secondary;
 
@@ -362,6 +367,14 @@ GIGO.identify_symptoms = function () {
         res.push("NAT64");
     }
 
+    // Warn IPv4-only users, if we're using TLS, that we can't detect Teredo/6to4
+    if (GIGO.protocol === "https://") {
+      console.log("checking https score exception");
+      if (mini_primary.match(/^[os][bt]/)) {
+        res.push("tls_warning");
+      }
+    }
+
     // Other transition technologies
     if (teredo) {
         if (aaaa === "bad") {
@@ -449,6 +462,11 @@ GIGO.identify_symptoms = function () {
         res.push("Unknown");
     }
     res = GIGO.dedupe_res(res);
+
+    console.log("score mini_primary=%o",mini_primary);
+    console.log("score mini_secondary=%o",mini_secondary);
+    console.log("score res=%o",res);
+
     return res;
 
 };


### PR DESCRIPTION
This has seen time on beta.test-ipv6.com - but not yet in production.

This does NOT attempt to identify http-only vs http+https "other site" and "mirror" resource urls (sites_parsed.json).  We still need to do work on the validation/testing tool that reads the site data and emits info on which sites are https capable.



