### PR TITLE
adds dark mode

### DIFF
--- a/templates/css/inc/color-schemes.inc
+++ b/templates/css/inc/color-schemes.inc
@@ -1,0 +1,80 @@
+/* Light mode */
+@media (prefers-color-scheme: light) {
+  body {
+      background-color: white;
+      color: black;
+  }
+
+  .tabbox_outside div {border: 1px solid #777777;}
+
+  .tabbox_inside div {border: 0px solid #000000;}
+
+  .tabbox_middle div {border: 0px solid #000000;}
+
+  /* Readiness Score */
+  th {
+    background-color: #000000;
+    color: #ffffff;
+  }
+
+  table.tablesorter tbody td {
+    color: #3D3D3D;
+    background-color: #FFF;
+  }
+  
+  table.tablesorter {background-color: #CDCDCD;}
+
+  .subtle a { color: #000; text-decoration: none; }
+  .subtle a:link { color: #000; }
+  .subtle a:visited { color: #000; }
+  .subtle a:hover { color: #00F; text-decoration: underline;}
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  body {
+      background-color: black;
+      color: white;
+  }
+
+  .tabbox_outside  div {border: 1px solid #ffffff;}
+  
+  .tabbox_inside div {border: 0px solid #ffffff;}
+
+  .tabbox_middle div {border: 0px solid #ffffff;}
+
+  /* Readiness Score */
+  th {
+    background-color: #ffffff;
+    color: #000000;
+  }
+
+  a:link {
+    color: white;
+  }
+  
+  a:visited {
+    color: #d3d3d3;
+  }
+  
+  a:hover {
+    color: #999999;
+  }
+  
+  a:active {
+    color: blue;
+  }
+
+  table.tablesorter tbody td {
+    color: #ffffff;
+    background-color: black;
+    }
+
+  table.tablesorter {
+    background-color: #cfcfcf;
+  }
+
+  a.permalink, a.goback, a.help_popup {
+    background-color: rgb(0, 4, 68);
+  }
+}

--- a/templates/css/inc/tabbox.inc
+++ b/templates/css/inc/tabbox.inc
@@ -1,21 +1,9 @@
-.tabbox_outside  div
-{
+.tabbox_outside div {
  width: 95%;
  margin-left: auto;
  margin-right: auto;
- border: 1px solid #777777;
 }
 
-.tabbox_middle div
-{
- width: 95%;
-  border: 0px solid #000000;
-}
+.tabbox_middle div {width: 95%;}
 
-.tabbox_inside div
-{
- width: 100%;
- background: #ffffff;
- background-color: #ffffff;
- border: 0px solid #000000;
-}
+.tabbox_inside div {width: 100%;}

--- a/templates/css/inc/tablesorter.inc
+++ b/templates/css/inc/tablesorter.inc
@@ -2,7 +2,6 @@
 /* tablesorter */
 table.tablesorter {
 	font-family:arial;
-	background-color: #CDCDCD;
 	margin:10px 0pt 15px;
 	font-size: 10pt;
 	width: 100%;

--- a/templates/css/index.css
+++ b/templates/css/index.css
@@ -73,11 +73,7 @@ color: #000;
   font-size: 80%;
 }
 
-th { 
-  background-color: #000000;
-  font-weight: bold;
-  color: #ffffff;
-}
+th {font-weight: bold;}
 
 td {vertical-align: top;}
 
@@ -117,37 +113,31 @@ a {  white-space:nowrap; }
 .status_ok {
   font-weight: bold;
   color: green;
-  background-color: white;
 }
 
 .status_safe {
   font-weight: bold;
   color: green;
-  background-color: white;
 }
 
 .status_slow {
   font-weight: bold;
   color: orange;
-  background-color: white;
 }
 
 .status_affected {
   font-weight: bold;
   color: red;
-  background-color: white;
 }
 
 .status_bad {
   font-weight: bold;
   color: blue;
-  background-color: white;
 }
 
 .status_timeout {
   font-weight: bold;
   color: red;
-  background-color: white;
 }
 
 
@@ -155,12 +145,6 @@ a {  white-space:nowrap; }
 [% PROCESS "inc/list-nav.inc" %]
 [% PROCESS "inc/tabnav.inc" %]
 [% PROCESS "inc/tabbox.inc" %]
-
-
-.subtle a { color: #000; text-decoration: none; }
-.subtle a:link { color: #000; }
-.subtle a:visited { color: #000; }
-.subtle a:hover { color: #00F; text-decoration: underline;}
 
 
 #about P {
@@ -277,6 +261,11 @@ div.nomail {
   margin: 0;
   padding: 0;
   background-color:#fbb;
+  color: #000000;
   top: 0;
   left: 0;
 }
+
+a.help_popup {color: blue;}
+
+[% PROCESS "inc/color-schemes.inc" %]


### PR DESCRIPTION
This PR adds CSS for dark mode, it is controlled by the visitor's browser with the [prefers-color-scheme media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)

Here is the [can I use](https://caniuse.com/?search=prefers-color-scheme) page for it. It is supported in all the latest browser versions.

I was not able to run the server to test it, I just modified the CSS and used the firefox style editor to make sure that it looks good, I then modified the CSS templates.

The changes to CSS are:
- removing hard-coded colors for many things and hard-coding the colors for others.
- and Defining the dark and light colors in a new file called color-schemes.inc.

Here are some screenshots:

Screenshot with 10/10
<img width="1680" alt="Screen Shot 2022-01-30 at 12 47 07 a m" src="https://user-images.githubusercontent.com/44717422/151689877-7597e4d6-e2cf-4816-ae1d-3950c6adf292.png">

Screenshot with 0/10
<img width="1680" alt="Screen Shot 2022-01-30 at 12 47 54 a m" src="https://user-images.githubusercontent.com/44717422/151689879-bb623caa-aa6b-4907-bcfa-88385625f9f0.png">

The IP addresses and ISP names are hidden for privacy.

The server setup docs look outdated and complicated, I would appreciate it if anyone could test the changes or give me more direct instructions on setting one up (I am familiar with Linux).

Once the page's CSS has the new dark-mode features, It can be tested by either changing your systems color-scheme to dark mode or with firefox's [color-scheme simulator buttons in the developer tools](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#view_media_rules_for_prefers-color-scheme).

The main issue that I noticed is that the loading animation's background is hard-coded to white. I don't know how to regenerate it with a transparent background and because it is only shown for a few seconds, I figured it didn't matter a lot.