### PR TITLE
removed mirror at BelWü

### DIFF
--- a/sites/sites.json
+++ b/sites/sites.json
@@ -271,15 +271,6 @@
       "v4": "https://ipv4.test-ipv6.karsolink.com/images-nc/knob_green.png",
       "v6": "https://ipv6.test-ipv6.karsolink.com/images-nc/knob_green.png"
     },
-    "test-ipv6.belwue.net": {
-      "hide": false,
-      "loc": "DE",
-      "mirror": true,
-      "monitor": "ip@belwue.de",
-      "provider": "Bel Wü",
-      "v4": "https://ipv4.test-ipv6.belwue.net/images-nc/knob_green.png",
-      "v6": "https://ipv6.test-ipv6.belwue.net/images-nc/knob_green.png"
-    },
     "test-ipv6.carnet.hr": {
       "hide": false,
       "loc": "HR",


### PR DESCRIPTION
removed the mirror, because BelWü is deprecating test-ipv6.belwue.net